### PR TITLE
feed-mob/tracking_admin#8939 update administrate gem

### DIFF
--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,docs}/**/*", "LICENSE", "Rakefile"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "actionpack", ">= 4.2", "< 5.2"
-  s.add_dependency "actionview", ">= 4.2", "< 5.2"
-  s.add_dependency "activerecord", ">= 4.2", "< 5.2"
+  s.add_dependency "actionpack", ">= 4.2"
+  s.add_dependency "actionview", ">= 4.2"
+  s.add_dependency "activerecord", ">= 4.2"
 
   s.add_dependency "autoprefixer-rails", ">= 6.0"
   s.add_dependency "datetime_picker_rails", "~> 0.0.7"

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"
   s.add_dependency "momentjs-rails", "~> 2.8"
-  s.add_dependency "sass-rails", "~> 5.0"
+  s.add_dependency "sass-rails", "~> 6.0"
   s.add_dependency "selectize-rails", "~> 0.6"
 
   s.description = <<-DESCRIPTION


### PR DESCRIPTION
- remove dependency rails < 5.2 
- 官方的移除了 rails < 的限制
- reference: https://github.com/thoughtbot/administrate/blob/master/administrate.gemspec